### PR TITLE
Remove redundant styles_qrc target

### DIFF
--- a/src/core/CalculatorModel.cpp
+++ b/src/core/CalculatorModel.cpp
@@ -5,7 +5,7 @@ CalculatorModel::CalculatorModel(QObject *parent)
 {
 }
 
-double CalculatorModel::sum(double a, double b) const
+double CalculatorModel::sum(double a, double b)
 {
     const double result = a + b;
     emit resultReady(result);          // Caso alguém se conecte

--- a/src/core/CalculatorModel.h
+++ b/src/core/CalculatorModel.h
@@ -12,7 +12,7 @@ public:
     explicit CalculatorModel(QObject *parent = nullptr);
 
     // Método síncrono: retorna o resultado na hora
-    double sum(double a, double b) const;
+    double sum(double a, double b);
 
 signals:
     // Exemplo de notificação assíncrona, caso queira usar

--- a/src/resources/CMakeLists.txt
+++ b/src/resources/CMakeLists.txt
@@ -1,6 +1,4 @@
 # src/resources/CMakeLists.txt
-qt_add_resources(styles_qrc
-    PREFIX /
-    FILES
-        styles.qrc          # o próprio .qrc; Qt varre e gera cpp
-)
+
+# The application directly embeds styles.qrc via src/app/CMakeLists.txt, so
+# no additional resource target is needed here.


### PR DESCRIPTION
## Summary
- remove the unused `styles_qrc` resource target
- adjust `CalculatorModel::sum` to allow building

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_6880598b07e4832f8f5494b1002a7339