### PR TITLE
Add day/night mode toggle

### DIFF
--- a/src/app/StyleHelper.cpp
+++ b/src/app/StyleHelper.cpp
@@ -3,6 +3,7 @@
 #include <QApplication>
 #include <QFile>
 #include <QPalette>
+#include <QTime>
 
 namespace {
 
@@ -32,23 +33,51 @@ QPalette buildDarkPalette()
     return pal;
 }
 
+/// Construir uma paleta "Light" simples
+QPalette buildLightPalette()
+{
+    QPalette pal;
+    pal.setColor(QPalette::Window,       QColor("#F0F0F0"));
+    pal.setColor(QPalette::WindowText,   QColor("#202020"));
+    pal.setColor(QPalette::Base,         QColor("#FFFFFF"));
+    pal.setColor(QPalette::AlternateBase,QColor("#E0E0E0"));
+    pal.setColor(QPalette::ToolTipBase,  QColor("#FFFFFF"));
+    pal.setColor(QPalette::ToolTipText,  QColor("#202020"));
+    pal.setColor(QPalette::Text,         QColor("#202020"));
+    pal.setColor(QPalette::Button,       QColor("#DDDDDD"));
+    pal.setColor(QPalette::ButtonText,   QColor("#202020"));
+    pal.setColor(QPalette::BrightText,   Qt::red);
+    pal.setColor(QPalette::Highlight,    QColor("#4A90E2"));
+    pal.setColor(QPalette::HighlightedText, Qt::white);
+    return pal;
+}
+
 } // anonymous namespace
 
 //======================================================================
 //  Public API
 //======================================================================
-void StyleHelper::apply()
+StyleHelper::Mode StyleHelper::initialMode()
+{
+    const int hour = QTime::currentTime().hour();
+    return (hour >= 6 && hour < 18) ? Mode::Day : Mode::Night;
+}
+
+void StyleHelper::apply(Mode mode)
 {
     //------------------------------------------------------------------
     // 1. Paleta de cores
     //------------------------------------------------------------------
-    qApp->setPalette(buildDarkPalette());
+    qApp->setPalette(mode == Mode::Night ? buildDarkPalette()
+                                         : buildLightPalette());
 
     //------------------------------------------------------------------
     // 2. Juntar e aplicar todas as folhas de estilo (.qss)
     //------------------------------------------------------------------
     const QString css =
-          loadQss(":/styles/core.qss")
+          loadQss(mode == Mode::Night
+                      ? ":/styles/core.qss"
+                      : ":/styles/core_light.qss")
         + loadQss(":/styles/buttons.qss")
         + loadQss(":/styles/inputs.qss");
 

--- a/src/app/StyleHelper.h
+++ b/src/app/StyleHelper.h
@@ -1,6 +1,11 @@
 #pragma once
 namespace StyleHelper
 {
-    /// Apply global palette + load all .qss fragments
-    void apply();
+    enum class Mode { Day, Night };
+
+    /// Determine initial mode based on local time
+    Mode initialMode();
+
+    /// Apply palette and styles for the chosen mode
+    void apply(Mode mode);
 }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -10,7 +10,8 @@ int main(int argc, char *argv[])
     //------------------------------------------------------------------
     // 1. Estilo global (cores, fontes, bordas) carregado via StyleHelper
     //------------------------------------------------------------------
-    StyleHelper::apply();          // lê todos os .qss embutidos no .qrc
+    StyleHelper::Mode mode = StyleHelper::initialMode();
+    StyleHelper::apply(mode);      // lê todos os .qss embutidos no .qrc
 
     //------------------------------------------------------------------
     // 2. Traducao (nao utilizado neste projeto)
@@ -19,7 +20,7 @@ int main(int argc, char *argv[])
     //------------------------------------------------------------------
     // 3. Criar e exibir a janela principal
     //------------------------------------------------------------------
-    MainWindow window;
+    MainWindow window(mode);
     window.show();
 
     return app.exec();             // loop de eventos

--- a/src/resources/styles.qrc
+++ b/src/resources/styles.qrc
@@ -1,6 +1,7 @@
 <RCC>
   <qresource prefix="/styles">
     <file>styles/core.qss</file>
+    <file>styles/core_light.qss</file>
     <file>styles/buttons.qss</file>
     <file>styles/inputs.qss</file>
   </qresource>

--- a/src/resources/styles/core_light.qss
+++ b/src/resources/styles/core_light.qss
@@ -1,0 +1,8 @@
+/* Paleta clara */
+QWidget {
+    background: #F0F0F0;
+    color: #202020;
+    font-family: "Arial";
+    font-size: 14pt;
+    font-weight: bold;
+}

--- a/src/ui/MainWindow.cpp
+++ b/src/ui/MainWindow.cpp
@@ -1,9 +1,13 @@
 #include "MainWindow.h"
 #include "CalcWidget.h"
 #include "../core/CalculatorModel.h"
+#include "../app/StyleHelper.h"
 
-MainWindow::MainWindow(QWidget *parent)
-    : QMainWindow(parent)
+#include <QToolBar>
+#include <QAction>
+
+MainWindow::MainWindow(StyleHelper::Mode mode, QWidget *parent)
+    : QMainWindow(parent), currentMode(mode)
 {
     // modelo de cálculo (pode crescer p/ outras operações)
     model = new CalculatorModel(this);
@@ -12,7 +16,32 @@ MainWindow::MainWindow(QWidget *parent)
     calc  = new CalcWidget(model, this);
     setCentralWidget(calc);
 
+    // botao de modo em uma toolbar simples
+    auto *tb = addToolBar("mode");
+    tb->setMovable(false);
+    modeAction = tb->addAction("");
+    connect(modeAction, &QAction::triggered,
+            this, &MainWindow::onToggleMode);
+    updateModeIcon();
+
     // metadados da janela
     setWindowTitle("Calculadora Qt – Aritmética");
     resize(360, 260);
+}
+
+void MainWindow::updateModeIcon()
+{
+    const QString icon =
+        (currentMode == StyleHelper::Mode::Night) ? QStringLiteral("\xF0\x9F\x8C\x99")
+                                                  : QStringLiteral("\xE2\x98\x80");
+    modeAction->setText(icon);
+}
+
+void MainWindow::onToggleMode()
+{
+    currentMode = (currentMode == StyleHelper::Mode::Night)
+                      ? StyleHelper::Mode::Day
+                      : StyleHelper::Mode::Night;
+    StyleHelper::apply(currentMode);
+    updateModeIcon();
 }

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <QMainWindow>
+#include <QAction>
+#include "../app/StyleHelper.h"
 
 class CalculatorModel;
 class CalcWidget;
@@ -8,10 +10,17 @@ class MainWindow final : public QMainWindow
 {
     Q_OBJECT
 public:
-    explicit MainWindow(QWidget *parent = nullptr);
+    explicit MainWindow(StyleHelper::Mode mode, QWidget *parent = nullptr);
     ~MainWindow() override = default;
 
+private slots:
+    void onToggleMode();
+
 private:
-    CalculatorModel *model{nullptr};
-    CalcWidget      *calc{nullptr};
+    void updateModeIcon();
+
+    CalculatorModel   *model{nullptr};
+    CalcWidget        *calc{nullptr};
+    QAction           *modeAction{nullptr};
+    StyleHelper::Mode  currentMode{StyleHelper::Mode::Day};
 };


### PR DESCRIPTION
## Summary
- add support for day and night palettes
- toggle mode automatically using system time or via toolbar button
- add light stylesheet to resources

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_688192e42748832f9d2c4753fdd180be